### PR TITLE
Crud/lost

### DIFF
--- a/src/controllers/Lost/createLost.ts
+++ b/src/controllers/Lost/createLost.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express'
+import useLost from '@services/Lost'
+
+const createLost = async (req: Request, res: Response) => {
+  try {
+    const lostRecord = await useLost.createLost(req.body)
+    res.status(201).json(lostRecord)
+  } catch (error: unknown) {
+    console.error('Error creating lost record:', error)
+    let errorMessage = 'Unknown error occurred'
+    let statusCode = 500
+
+    if (error instanceof Error) {
+      errorMessage = error.message
+      statusCode = error.message.includes('no encontrado') ? 404 : 500
+    }
+    res.status(statusCode).json({
+      error: statusCode === 404 ? 'Not Found' : 'Internal Server Error',
+      message: errorMessage,
+    })
+  }
+}
+
+export default createLost

--- a/src/controllers/Lost/deleteLost.ts
+++ b/src/controllers/Lost/deleteLost.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express'
+import useLost from '@services/Lost'
+
+const deleteLost = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params
+    await useLost.deleteLost(id)
+    res.status(204).send()
+  } catch (error: unknown) {
+    console.error('Error deleting lost record:', error)
+    // Manejo seguro de errores
+    let statusCode = 500
+    let errorMessage = 'Unknown error occurred'
+    if (error instanceof Error) {
+      errorMessage = error.message
+      statusCode = error.message.includes('no encontrado') ? 404 : 500
+    }
+    res.status(statusCode).json({
+      error: statusCode === 404 ? 'Not Found' : 'Internal Server Error',
+      message: errorMessage,
+    })
+  }
+}
+
+export default deleteLost

--- a/src/controllers/Lost/getAllLost.ts
+++ b/src/controllers/Lost/getAllLost.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express'
+import useLost from '@services/Lost'
+
+const getAllLost = async (req: Request, res: Response) => {
+  try {
+    const filters = {
+      product_id: req.query.product_id as string,
+      lost_type: req.query.lost_type as string,
+      start_date: req.query.start_date
+        ? new Date(req.query.start_date as string)
+        : undefined,
+      end_date: req.query.end_date
+        ? new Date(req.query.end_date as string)
+        : undefined,
+    }
+    const lostRecords = await useLost.getAllLost(filters)
+    res.status(200).json(lostRecords)
+  } catch (error) {
+    console.error('Error getting lost records:', error)
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    })
+  }
+}
+
+export default getAllLost

--- a/src/controllers/Lost/getLostById.ts
+++ b/src/controllers/Lost/getLostById.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express'
+import useLost from '@services/Lost'
+
+const getLostById = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params
+    const lostRecord = await useLost.getLostById(id)
+    res.status(200).json(lostRecord)
+  } catch (error: unknown) {
+    console.error('Error getting lost record:', error)
+    // Manejo seguro del error
+    let errorMessage = 'Unknown error occurred'
+    let statusCode = 500
+    if (error instanceof Error) {
+      errorMessage = error.message
+      statusCode = error.message.includes('no encontrado') ? 404 : 500
+    }
+    res.status(statusCode).json({
+      error: statusCode === 404 ? 'Not Found' : 'Internal Server Error',
+      message: errorMessage,
+    })
+  }
+}
+
+export default getLostById

--- a/src/controllers/Lost/index.ts
+++ b/src/controllers/Lost/index.ts
@@ -1,0 +1,13 @@
+import createLost from './createLost'
+import getAllLost from './getAllLost'
+import getLostById from './getLostById'
+import updateLost from './updateLost'
+import deleteLost from './deleteLost'
+
+export default {
+  createLost,
+  getAllLost,
+  getLostById,
+  updateLost,
+  deleteLost,
+}

--- a/src/controllers/Lost/updateLost.ts
+++ b/src/controllers/Lost/updateLost.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express'
+import useLost from '@services/Lost'
+
+const updateLost = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params
+    const updatedRecord = await useLost.updateLost(id, req.body)
+    res.status(200).json(updatedRecord)
+  } catch (error: unknown) {
+    console.error('Error updating lost record:', error)
+    let errorMessage = 'Unknown error occurred'
+    let statusCode = 500
+    if (error instanceof Error) {
+      errorMessage = error.message
+      statusCode = error.message.includes('no encontrado') ? 404 : 500
+    }
+    res.status(statusCode).json({
+      error: statusCode === 404 ? 'Not Found' : 'Internal Server Error',
+      message: errorMessage,
+    })
+  }
+}
+
+export default updateLost

--- a/src/routes/lost.ts
+++ b/src/routes/lost.ts
@@ -1,0 +1,12 @@
+import express from 'express'
+import authorization from '@middlewares/authorization'
+import lostController from '@controllers/Lost'
+
+const router = express.Router()
+router.post('/', authorization, lostController.createLost)
+router.get('/', authorization, lostController.getAllLost)
+router.get('/:id', authorization, lostController.getLostById)
+router.patch('/:id', authorization, lostController.updateLost)
+router.delete('/:id', authorization, lostController.deleteLost)
+
+export default router

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import authorization from '@middlewares/authorization'
-import userController from '@controllers/user'
+import userController from '@controllers/Userser'
 
 const router = express.Router()
 

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import authorization from '@middlewares/authorization'
-import userController from '@controllers/Userser'
+import userController from '@controllers/User'
 
 const router = express.Router()
 

--- a/src/services/Lost/index.ts
+++ b/src/services/Lost/index.ts
@@ -1,0 +1,15 @@
+import createLost from './serviceCreateLost'
+import getAllLost from './serviceGetAllLost'
+import getLostById from './serviceGetLostById'
+import updateLost from './serviceUpdateLost'
+import deleteLost from './serviceDeleteLost'
+
+const useLost = {
+  createLost,
+  getAllLost,
+  getLostById,
+  updateLost,
+  deleteLost,
+}
+
+export default useLost

--- a/src/services/Lost/serviceCreateLost.ts
+++ b/src/services/Lost/serviceCreateLost.ts
@@ -1,0 +1,23 @@
+import Lost from '@models/lost'
+import Product from '@models/product'
+import { lostAttributes } from '@type/production/lost'
+
+export default async function createLost(
+  lostData: Omit<lostAttributes, 'id' | 'created_at'>,
+) {
+  try {
+    const product = await Product.findByPk(lostData.product_id)
+    if (!product) {
+      throw new Error('Producto no encontrado')
+    }
+    const newLost = await Lost.create({
+      ...lostData,
+      created_at: new Date(),
+    })
+    return newLost
+  } catch (error) {
+    throw new Error(
+      `Error al crear registro de pérdida: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/src/services/Lost/serviceDeleteLost.ts
+++ b/src/services/Lost/serviceDeleteLost.ts
@@ -1,0 +1,17 @@
+import Lost from '@models/lost'
+
+export default async function deleteLost(id: string) {
+  try {
+    const lost = await Lost.findByPk(id)
+    if (!lost) {
+      throw new Error('Registro de pérdida no encontrado')
+    }
+
+    await lost.destroy()
+    return { message: 'Registro de pérdida eliminado correctamente' }
+  } catch (error) {
+    throw new Error(
+      `Error al eliminar registro de pérdida: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/src/services/Lost/serviceGetAllLost.ts
+++ b/src/services/Lost/serviceGetAllLost.ts
@@ -1,0 +1,59 @@
+import Lost from '@models/lost'
+import Product from '@models/product'
+import { Op, WhereOptions } from 'sequelize'
+
+interface Filters {
+  product_id?: string
+  lost_type?: string
+  start_date?: Date
+  end_date?: Date
+}
+
+interface LostWhereConditions {
+  product_id?: string
+  lost_type?: string
+  created_at?: {
+    [Op.between]?: [Date, Date]
+    [Op.gte]?: Date
+    [Op.lte]?: Date
+  }
+}
+
+export default async function getAllLost(filters?: Filters) {
+  try {
+    const where: WhereOptions<LostWhereConditions> = {}
+
+    if (filters?.product_id) {
+      where.product_id = filters.product_id
+    }
+
+    if (filters?.lost_type) {
+      where.lost_type = filters.lost_type
+    }
+
+    if (filters?.start_date && filters?.end_date) {
+      where.created_at = {
+        [Op.between]: [filters.start_date, filters.end_date],
+      }
+    } else if (filters?.start_date) {
+      where.created_at = {
+        [Op.gte]: filters.start_date,
+      }
+    } else if (filters?.end_date) {
+      where.created_at = {
+        [Op.lte]: filters.end_date,
+      }
+    }
+
+    const losts = await Lost.findAll({
+      include: [Product],
+      order: [['created_at', 'DESC']],
+    })
+
+    return losts
+  } catch (error) {
+    throw new Error(
+      `Error al obtener registros de pérdida: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/src/services/Lost/serviceGetLostById.ts
+++ b/src/services/Lost/serviceGetLostById.ts
@@ -1,0 +1,20 @@
+import Lost from '@models/lost'
+import Product from '@models/product'
+
+export default async function getLostById(id: string) {
+  try {
+    const lost = await Lost.findByPk(id, {
+      include: [Product],
+    })
+
+    if (!lost) {
+      throw new Error('Registro de pérdida no encontrado')
+    }
+
+    return lost
+  } catch (error) {
+    throw new Error(
+      `Error al obtener registro de pérdida: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/src/services/Lost/serviceUpdateLost.ts
+++ b/src/services/Lost/serviceUpdateLost.ts
@@ -1,0 +1,29 @@
+import Lost from '@models/lost'
+import Product from '@models/product'
+import { lostAttributes } from '@type/production/lost'
+
+export default async function updateLost(
+  id: string,
+  updateData: Partial<Omit<lostAttributes, 'id' | 'created_at'>>,
+) {
+  try {
+    const lost = await Lost.findByPk(id)
+    if (!lost) {
+      throw new Error('Registro de pérdida no encontrado')
+    }
+
+    if (updateData.product_id) {
+      const product = await Product.findByPk(updateData.product_id)
+      if (!product) {
+        throw new Error('Producto no encontrado')
+      }
+    }
+
+    await lost.update(updateData)
+    return lost
+  } catch (error) {
+    throw new Error(
+      `Error al actualizar registro de pérdida: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}


### PR DESCRIPTION
Solucion error de User 
![image](https://github.com/user-attachments/assets/fe4691dd-3f1e-4444-ad84-18f7b90ae835)
Se realizo un CRUD para la tabla lost la cual esta ordenado con el sistema modular en cuanto a controles y servicios, para luego realizar pruebas con Postman.
Evidencia: 
![Imagen de WhatsApp 2025-04-30 a las 17 30 48_f7a77e53](https://github.com/user-attachments/assets/fd52a81f-ec25-4e91-be6a-b00484d97a62)
![Imagen de WhatsApp 2025-04-30 a las 17 31 22_69392cee](https://github.com/user-attachments/assets/d2dfaf8b-5cab-4b05-a27e-e73a46df6cbf)
![Imagen de WhatsApp 2025-04-30 a las 17 31 50_0eac3a9d](https://github.com/user-attachments/assets/fbc26c52-11d9-4cd0-9cec-32669705f84d)
![Imagen de WhatsApp 2025-04-30 a las 17 32 27_f15e642d](https://github.com/user-attachments/assets/5caa1068-872d-4516-bce4-3290ccedabde)
