### PR TITLE
feat: CreateWarehousemovement on production Creation

### DIFF
--- a/src/models/entrance.ts
+++ b/src/models/entrance.ts
@@ -45,8 +45,17 @@ Entrance.init(
 
 // Relaciones
 Entrance.belongsTo(User, { foreignKey: 'user_id', as: 'user' })
-Entrance.belongsTo(TypePerson, { foreignKey: 'type_person_id', as: 'type_person' })
-Entrance.belongsTo(SalesChannel, { foreignKey: 'sale_channel', as: 'sales_channel' })
-Entrance.belongsTo(PaymentMethod, { foreignKey: 'payment_method', as: 'payment_method_obj' })
+Entrance.belongsTo(TypePerson, {
+  foreignKey: 'type_person_id',
+  as: 'type_person',
+})
+Entrance.belongsTo(SalesChannel, {
+  foreignKey: 'sale_channel',
+  as: 'sales_channel',
+})
+Entrance.belongsTo(PaymentMethod, {
+  foreignKey: 'payment_method',
+  as: 'payment_method_obj',
+})
 
 export default Entrance

--- a/src/schemas/production/productionSchema.ts
+++ b/src/schemas/production/productionSchema.ts
@@ -22,6 +22,8 @@ const productionSchema = z.object({
 
   plant_id: z.string().uuid('El ID de la planta debe ser un UUID válido'),
 
+  warehouse_id: z.string().uuid('El ID del almacén debe ser un UUID válido'),
+
   createdAt: z.date().optional(),
 
   updatedAt: z.date().optional(),

--- a/src/services/Production/serviceCreateProduction.ts
+++ b/src/services/Production/serviceCreateProduction.ts
@@ -3,13 +3,21 @@ import { productionAttributes } from '@type/production/production'
 import { productionValidation } from 'src/schemas/production/productionSchema'
 import Product from '@models/product'
 import PlantProduction from '@models/plant_production'
+import serviceCreatewarehouseMovementProduct from '../warehouse_movement_product/serviceCreatewarehouse_movement_product'
+import { WarehouseMovomentProductAttributes } from '@type/almacen/warehouse_movement_product'
 
 const serviceCreateProduction = async (body: productionAttributes) => {
   const validation = productionValidation(body)
   if (!validation.success) return { error: validation.error.errors }
 
-  const { productId, quantityProduced, productionDate, observation, plant_id } =
-    validation.data
+  const {
+    productId,
+    quantityProduced,
+    productionDate,
+    observation,
+    plant_id,
+    warehouse_id,
+  } = validation.data
 
   const product = await Product.findByPk(productId)
   if (!product) return { error: 'El producto no existe' }
@@ -17,13 +25,41 @@ const serviceCreateProduction = async (body: productionAttributes) => {
   const plant = await PlantProduction.findByPk(plant_id)
   if (!plant) return { error: 'La planta no existe' }
 
+  // TODO: Validate warehouse_id exists - For a future iteration if necessary
+
   const newProduction = await Production.create({
     productId,
     quantityProduced,
     productionDate,
     observation: observation ?? '',
     plant_id,
+    // warehouse_id is not part of the Production model itself based on current structure
   })
+
+  // Create warehouse movement product
+  const movementData: WarehouseMovomentProductAttributes = {
+    warehouse_id,
+    product_id: newProduction.productId,
+    movement_type: 'entrada',
+    quantity: newProduction.quantityProduced,
+    movement_date: new Date(newProduction.productionDate), // Ensure it's a Date object
+    observations: `Entrada por producción ID: ${newProduction.id}${observation ? ' - ' + observation : ''}`,
+    // store_id is optional and can be omitted or set to null
+  }
+
+  const movementResult =
+    await serviceCreatewarehouseMovementProduct(movementData)
+
+  if (!movementResult.success) {
+    // Log the error or handle it as per application requirements
+    // For now, we'll log it and still return the production data
+    console.error(
+      'Error creating warehouse movement product:',
+      movementResult.error,
+    )
+    // Potentially, you might want to roll back the production creation here
+    // or return a specific error indicating partial failure.
+  }
 
   const datosFinales = {
     id: newProduction.id,
@@ -32,6 +68,8 @@ const serviceCreateProduction = async (body: productionAttributes) => {
     fecha_produccion: productionDate,
     observacion: observation,
     planta: plant.plant_name,
+    warehouse_id: warehouse_id, // Include warehouse_id in the response
+    movement_id: movementResult.success ? movementResult.movement?.id : null,
   }
 
   console.log('📄 Datos de la producción creada:', datosFinales)


### PR DESCRIPTION
Función: Crear un movimiento de almacén al crear la producción

- Actualizar la entrada de producción para incluir warehouse_id.
- Llamar a serviceCreatewarehouseMovementProduct al iniciar una nueva producción para registrar un movimiento de entrada.
- Actualizar el esquema de validación relevantes.