### PR TITLE
Feat: Changing models, types, and schemes in the cash session

### DIFF
--- a/src/models/cashSession.ts
+++ b/src/models/cashSession.ts
@@ -9,8 +9,8 @@ class CashSession
   implements CashSessionAttributes
 {
   public id!: string
-  public user_id!: number
-  public store_id!: number
+  public user_id!: string
+  public store_id!: string
   public start_amount!: number
   public end_amount!: number
   public total_returns!: number
@@ -29,11 +29,11 @@ CashSession.init(
       primaryKey: true,
     },
     user_id: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.STRING,
       allowNull: false,
     },
     store_id: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.STRING,
       allowNull: false,
     },
     start_amount: {

--- a/src/schemas/ventas/cashSessionSchema.ts
+++ b/src/schemas/ventas/cashSessionSchema.ts
@@ -3,20 +3,18 @@ import { z } from 'zod'
 
 const cashSessionSchema = z.object({
   user_id: z
-    .number({
+    .string({
       required_error: 'El ID del usuario es obligatorio',
-      invalid_type_error: 'El ID del usuario debe ser un número',
+      invalid_type_error: 'El ID del usuario debe ser un string UUID',
     })
-    .int()
-    .positive('El ID del usuario debe ser mayor que cero'),
+    .uuid('El ID del usuario debe ser un UUID válido'),
 
   store_id: z
-    .number({
+    .string({
       required_error: 'El ID de la tienda es obligatorio',
-      invalid_type_error: 'El ID de la tienda debe ser un número',
+      invalid_type_error: 'El ID de la tienda debe ser un string UUID',
     })
-    .int()
-    .positive('El ID de la tienda debe ser mayor que cero'),
+    .uuid('El ID de la tienda debe ser un UUID válido'),
 
   start_amount: z
     .number({

--- a/src/types/ventas/cashSession.d.ts
+++ b/src/types/ventas/cashSession.d.ts
@@ -1,7 +1,7 @@
 export interface CashSessionAttributes {
   id?: string
-  user_id: number
-  store_id: number
+  user_id: string
+  store_id: string
   start_amount: number
   end_amount: number
   total_returns: number


### PR DESCRIPTION
Se migraron los modelos, esquemas y tipos relacionados con cash_session para que los campos user_id y store_id utilicen UUID (string) en vez de IDs numéricos.
Se actualizaron los controladores y servicios para aceptar y validar correctamente UUIDs en las operaciones de creación, consulta y filtrado de cierres de caja.
Se corrigieron validaciones y conversiones de tipos en los endpoints para evitar rechazos por incompatibilidad de tipos.
Se mejoró la coherencia en el manejo de IDs en todos los endpoints relacionados con caja, igualando el patrón de los módulos de producción.
Se agregaron logs y validaciones adicionales para facilitar la depuración y evitar errores silenciosos.
Se mantuvo la compatibilidad con el frontend, permitiendo la selección de usuarios y tiendas por UUID.